### PR TITLE
Update miner API endpoints for Sia v1.0

### DIFF
--- a/network.cpp
+++ b/network.cpp
@@ -64,8 +64,8 @@ void network_init(const char *domain, const char *port, const char *useragent)
 		printf("\nmalloc error\n");
 		exit(EXIT_FAILURE);
 	}
-	sprintf(bfw_url, "http://%s:%s/miner/headerforwork", domain, port);
-	sprintf(submit_url, "http://%s:%s/miner/submitheader", domain, port);
+	sprintf(bfw_url, "http://%s:%s/miner/header", domain, port);
+	sprintf(submit_url, "http://%s:%s/miner/header", domain, port);
 	/*
 	res = curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
 	if(res != CURLE_OK)

--- a/network.cpp
+++ b/network.cpp
@@ -111,7 +111,7 @@ int check_http_response(CURL *curl)
 	CURLcode err = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 	if(err == CURLE_OK)
 	{
-		if(http_code != 200 && http_code != 0)
+		if(http_code != 200 && http_code != 204 && http_code != 0)
 		{
 			fprintf(stderr, "\nHTTP error %lu", http_code);
 			if(http_code == 400)


### PR DESCRIPTION
`GET /miner/headerforwork` and `POST /miner/submitheader` have been deprecated since Sia v0.4.8. They are being removed in favor of `GET /miner/header` and `POST /miner/header`, respectively in Sia v1.0.

Success responses with no returned data are now returned as 204 No Content instead of 200 OK as per NebulousLabs/Sia#1249. Specifically:
* `GET /header` returns `200 OK` + the header in the response body on success
* `POST /header` returns `204 No Content` on success